### PR TITLE
Add repository URL to package.json for npm reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "tauri-astro-app",
   "private": false,
   "version": "0.0.4",
+  "repository": {
+    "url": "https://github.com/miguelgargallo/tauri-astro-app"
+  },
   "type": "module",
   "scripts": {
     "dev": "astro dev",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": {
     "url": "https://github.com/miguelgargallo/tauri-astro-app"
   },
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
Was directed to npmjs (https://www.npmjs.com/package/astro-tauri-app) on twitter (Tauri retweet). Couldn't find the repository until you had tweeted it.

This should add the link to the npmjs page (assuming you want the link on there, feel free to close if you don't)